### PR TITLE
feat: 日報一覧表示機能の実装完了 (Story 7)

### DIFF
--- a/src/app/(auth)/login/page.tsx
+++ b/src/app/(auth)/login/page.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState } from 'react';
+import React, { useState } from 'react';
 import { useRouter } from 'next/navigation';
 import Link from 'next/link';
 import { useForm } from 'react-hook-form';
@@ -18,6 +18,7 @@ import {
   CardTitle,
 } from '@/components/ui/card';
 import { Alert, AlertDescription } from '@/components/ui/alert';
+import { useAuth } from '@/contexts/AuthContext';
 
 const loginSchema = z.object({
   email: z.string().email('有効なメールアドレスを入力してください'),
@@ -30,7 +31,9 @@ export default function LoginPage() {
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const router = useRouter();
+  const { user, loading } = useAuth();
 
+  // フォームの初期化（hooksは条件分岐より前に配置）
   const form = useForm<LoginForm>({
     resolver: zodResolver(loginSchema),
     defaultValues: {
@@ -38,6 +41,21 @@ export default function LoginPage() {
       password: '',
     },
   });
+
+  // 既にログインしている場合はダッシュボードにリダイレクト
+  React.useEffect(() => {
+    if (user) {
+      console.log('✅ 既にログイン済み、ダッシュボードにリダイレクト');
+      router.push('/dashboard');
+    }
+  }, [user, router]);
+
+  // 既にログインしている場合は何も表示しない（リダイレクト中）
+  if (user) {
+    return null;
+  }
+
+  // ログイン画面を表示（認証状態の初回チェックは気にしない）
 
   const onSubmit = async (data: LoginForm) => {
     console.log('🔄 ログイン開始:', data.email);
@@ -61,10 +79,13 @@ export default function LoginPage() {
 
       if (authData.user) {
         console.log('✅ ログイン成功:', authData.user.id);
-        console.log('🔄 ダッシュボードにリダイレクト中...');
+        console.log('🔄 認証状態更新を待機中...');
 
-        // 強制的にリダイレクト
-        window.location.href = '/dashboard';
+        // AuthContextが状態を更新するまで少し待つ
+        setTimeout(() => {
+          console.log('🔄 ダッシュボードにリダイレクト');
+          router.push('/dashboard');
+        }, 1000);
         return;
       }
     } catch (error: any) {

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -35,8 +35,16 @@ function DashboardContent() {
   const [statsLoading, setStatsLoading] = useState(true);
   const [recentReports, setRecentReports] = useState<any[]>([]);
 
+  // 全てのhooksを条件分岐より前に配置
   useEffect(() => {
+    console.log('📊 Dashboard認証チェック:', {
+      loading,
+      user: !!user,
+      userId: user?.id,
+    });
+    // 初回読み込み完了後に未認証ならリダイレクト
     if (!loading && !user) {
+      console.log('❌ 未認証のためログインページにリダイレクト');
       router.push('/login');
     }
   }, [user, loading, router]);
@@ -75,34 +83,22 @@ function DashboardContent() {
     fetchDashboardData();
   }, [user]);
 
-  if (loading) {
+  // hooksの後に条件分岐
+  // 初回の認証状態確認中のみローディング表示（短時間）
+  if (loading && !user) {
     return (
-      <MainLayout>
-        <div className="space-y-8">
-          <div className="bg-gray-200 rounded-lg p-6 animate-pulse">
-            <div className="h-6 bg-gray-300 rounded mb-2"></div>
-            <div className="h-4 bg-gray-300 rounded w-2/3"></div>
-          </div>
-          <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-4">
-            {[...Array(4)].map((_, i) => (
-              <Card key={i}>
-                <CardContent className="p-6">
-                  <div className="animate-pulse">
-                    <div className="h-4 bg-gray-200 rounded mb-4"></div>
-                    <div className="h-8 bg-gray-200 rounded mb-2"></div>
-                    <div className="h-3 bg-gray-200 rounded w-1/2"></div>
-                  </div>
-                </CardContent>
-              </Card>
-            ))}
-          </div>
+      <div className="flex items-center justify-center min-h-screen">
+        <div className="text-center">
+          <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-blue-600 mx-auto mb-4"></div>
+          <p className="text-gray-600">認証状態を確認中...</p>
         </div>
-      </MainLayout>
+      </div>
     );
   }
 
+  // 認証状態確認完了後、未認証の場合はリダイレクト中
   if (!user) {
-    return null; // リダイレクト中
+    return null;
   }
 
   return (
@@ -246,7 +242,7 @@ function DashboardContent() {
                 className="w-full justify-start"
                 size="lg"
               >
-                <Link href="/reports">
+                <Link href="/reports/list">
                   <BookOpenIcon className="mr-2 h-4 w-4" />
                   日報履歴を確認
                 </Link>

--- a/src/app/reports/list/page.tsx
+++ b/src/app/reports/list/page.tsx
@@ -1,0 +1,551 @@
+'use client';
+
+import { useState, useEffect } from 'react';
+import Link from 'next/link';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Button } from '@/components/ui/button';
+import {
+  PlusIcon,
+  CalendarIcon,
+  TableIcon,
+  FilterIcon,
+  SearchIcon,
+} from 'lucide-react';
+import { useAuth } from '@/contexts/AuthContext';
+import { getDailyReportsWithCount } from '@/lib/supabase/queries/daily-reports';
+import type { DailyReport } from '@/types/database';
+import { CalendarView } from '@/components/calendar/CalendarView';
+
+// フィルター条件の型定義
+interface FilterOptions {
+  startDate: string;
+  endDate: string;
+  workStatus: '' | 'worked' | 'not-worked';
+  searchQuery: string;
+}
+
+// ページネーション設定
+const ITEMS_PER_PAGE = 10;
+
+export default function DailyReportsListPage() {
+  const { user, userProfile } = useAuth();
+  const [currentView, setCurrentView] = useState<'table' | 'calendar'>('table');
+
+  // データ状態
+  const [reports, setReports] = useState<DailyReport[]>([]);
+  const [totalCount, setTotalCount] = useState(0);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  // ページネーション状態
+  const [currentPage, setCurrentPage] = useState(1);
+
+  // フィルター状態
+  const [filters, setFilters] = useState<FilterOptions>({
+    startDate: '',
+    endDate: '',
+    workStatus: '',
+    searchQuery: '',
+  });
+
+  // フィルターの表示/非表示
+  const [showFilters, setShowFilters] = useState(false);
+
+  // データ取得関数
+  const fetchReports = async () => {
+    if (!user?.id) return;
+
+    setLoading(true);
+    setError(null);
+
+    try {
+      const offset = (currentPage - 1) * ITEMS_PER_PAGE;
+      const options = {
+        startDate: filters.startDate || undefined,
+        endDate: filters.endDate || undefined,
+        isWorked:
+          filters.workStatus === 'worked'
+            ? true
+            : filters.workStatus === 'not-worked'
+            ? false
+            : undefined,
+        searchQuery: filters.searchQuery || undefined,
+        limit: ITEMS_PER_PAGE,
+        offset,
+      };
+
+      const { reports: fetchedReports, totalCount: count } =
+        await getDailyReportsWithCount(user.id, options);
+
+      setReports(fetchedReports);
+      setTotalCount(count);
+    } catch (err) {
+      console.error('日報一覧取得エラー:', err);
+      setError('データの取得に失敗しました');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  // 初回ロードとフィルター・ページ変更時のデータ取得
+  useEffect(() => {
+    fetchReports();
+  }, [user?.id, currentPage, filters]);
+
+  // フィルター更新関数
+  const updateFilters = (newFilters: Partial<FilterOptions>) => {
+    setFilters((prev) => ({ ...prev, ...newFilters }));
+    setCurrentPage(1); // フィルター変更時は1ページ目に戻る
+  };
+
+  // ページネーション情報
+  const totalPages = Math.ceil(totalCount / ITEMS_PER_PAGE);
+  const startIndex = (currentPage - 1) * ITEMS_PER_PAGE + 1;
+  const endIndex = Math.min(currentPage * ITEMS_PER_PAGE, totalCount);
+
+  return (
+    <div className="container mx-auto py-8 px-4">
+      {/* ページヘッダー */}
+      <div className="flex flex-col sm:flex-row justify-between items-start sm:items-center gap-4 mb-8">
+        <div>
+          <h1 className="text-3xl font-bold text-gray-900 mb-2">日報一覧</h1>
+          <p className="text-gray-600">過去の稼働記録を確認・編集できます</p>
+        </div>
+
+        {/* 新規作成ボタン */}
+        <Link href="/reports">
+          <Button className="flex items-center gap-2">
+            <PlusIcon className="h-4 w-4" />
+            新しい日報を作成
+          </Button>
+        </Link>
+      </div>
+
+      {/* 表示切り替えとフィルター */}
+      <Card className="mb-6">
+        <CardHeader>
+          <div className="flex flex-col sm:flex-row justify-between items-start sm:items-center gap-4">
+            {/* ビュー切り替えタブ */}
+            <div className="flex bg-gray-100 rounded-lg p-1">
+              <button
+                onClick={() => setCurrentView('table')}
+                className={`flex items-center gap-2 px-4 py-2 rounded-md text-sm font-medium transition-colors ${
+                  currentView === 'table'
+                    ? 'bg-white text-gray-900 shadow-sm'
+                    : 'text-gray-600 hover:text-gray-900'
+                }`}
+              >
+                <TableIcon className="h-4 w-4" />
+                テーブル表示
+              </button>
+              <button
+                onClick={() => setCurrentView('calendar')}
+                className={`flex items-center gap-2 px-4 py-2 rounded-md text-sm font-medium transition-colors ${
+                  currentView === 'calendar'
+                    ? 'bg-white text-gray-900 shadow-sm'
+                    : 'text-gray-600 hover:text-gray-900'
+                }`}
+              >
+                <CalendarIcon className="h-4 w-4" />
+                カレンダー表示
+              </button>
+            </div>
+
+            {/* フィルターボタン */}
+            <Button
+              variant="outline"
+              className="flex items-center gap-2"
+              onClick={() => setShowFilters(!showFilters)}
+            >
+              <FilterIcon className="h-4 w-4" />
+              フィルター
+            </Button>
+          </div>
+        </CardHeader>
+
+        {showFilters && (
+          <CardContent>
+            {/* 検索バー */}
+            <div className="mb-4">
+              <label className="block text-sm font-medium text-gray-700 mb-1">
+                検索（メモから検索）
+              </label>
+              <div className="relative">
+                <SearchIcon className="absolute left-3 top-1/2 transform -translate-y-1/2 h-4 w-4 text-gray-400" />
+                <input
+                  type="text"
+                  placeholder="メモやコメントから検索..."
+                  value={filters.searchQuery}
+                  onChange={(e) =>
+                    updateFilters({ searchQuery: e.target.value })
+                  }
+                  className="w-full pl-10 pr-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500"
+                />
+              </div>
+            </div>
+
+            {/* フィルター項目 */}
+            <div className="grid grid-cols-1 sm:grid-cols-3 gap-4 mb-4">
+              <div>
+                <label className="block text-sm font-medium text-gray-700 mb-1">
+                  期間（開始日）
+                </label>
+                <input
+                  type="date"
+                  value={filters.startDate}
+                  onChange={(e) => updateFilters({ startDate: e.target.value })}
+                  className="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500"
+                />
+              </div>
+              <div>
+                <label className="block text-sm font-medium text-gray-700 mb-1">
+                  期間（終了日）
+                </label>
+                <input
+                  type="date"
+                  value={filters.endDate}
+                  onChange={(e) => updateFilters({ endDate: e.target.value })}
+                  className="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500"
+                />
+              </div>
+              <div>
+                <label className="block text-sm font-medium text-gray-700 mb-1">
+                  作業状況
+                </label>
+                <select
+                  value={filters.workStatus}
+                  onChange={(e) =>
+                    updateFilters({
+                      workStatus: e.target.value as
+                        | ''
+                        | 'worked'
+                        | 'not-worked',
+                    })
+                  }
+                  className="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500"
+                >
+                  <option value="">すべて</option>
+                  <option value="worked">作業日</option>
+                  <option value="not-worked">非作業日</option>
+                </select>
+              </div>
+            </div>
+
+            {/* フィルターリセットボタン */}
+            <div className="flex justify-end">
+              <Button
+                variant="outline"
+                size="sm"
+                onClick={() => {
+                  setFilters({
+                    startDate: '',
+                    endDate: '',
+                    workStatus: '',
+                    searchQuery: '',
+                  });
+                }}
+              >
+                フィルターをリセット
+              </Button>
+            </div>
+          </CardContent>
+        )}
+      </Card>
+
+      {/* メインコンテンツエリア */}
+      <Card>
+        <CardHeader>
+          <div className="flex justify-between items-center">
+            <CardTitle className="text-lg">
+              {currentView === 'table' ? 'テーブル表示' : 'カレンダー表示'}
+            </CardTitle>
+            {totalCount > 0 && (
+              <p className="text-sm text-gray-600">
+                全{totalCount}件中 {startIndex}〜{endIndex}件を表示
+              </p>
+            )}
+          </div>
+        </CardHeader>
+
+        <CardContent className="p-6">
+          {loading ? (
+            // ローディング状態
+            <div className="text-center py-12">
+              <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-blue-600 mx-auto mb-4"></div>
+              <p className="text-gray-600">データを読み込んでいます...</p>
+            </div>
+          ) : error ? (
+            // エラー状態
+            <div className="text-center py-12">
+              <p className="text-red-600 mb-4">{error}</p>
+              <Button onClick={fetchReports} variant="outline">
+                再試行
+              </Button>
+            </div>
+          ) : reports.length === 0 ? (
+            // データが空の状態
+            <div className="text-center py-12">
+              <TableIcon className="mx-auto h-12 w-12 text-gray-400 mb-4" />
+              <h3 className="text-lg font-medium text-gray-900 mb-2">
+                日報データがありません
+              </h3>
+              <p className="text-gray-600 mb-4">
+                条件に合致する日報が見つかりませんでした
+              </p>
+              <Link href="/reports">
+                <Button>新しい日報を作成</Button>
+              </Link>
+            </div>
+          ) : currentView === 'table' ? (
+            // テーブル表示
+            <div className="space-y-4">
+              {/* デスクトップテーブル表示 */}
+              <div className="hidden md:block overflow-x-auto">
+                <table className="w-full border-collapse border border-gray-200">
+                  <thead className="bg-gray-50">
+                    <tr>
+                      <th className="border border-gray-200 px-4 py-3 text-left text-sm font-medium text-gray-700">
+                        日付
+                      </th>
+                      <th className="border border-gray-200 px-4 py-3 text-left text-sm font-medium text-gray-700">
+                        稼働状況
+                      </th>
+                      <th className="border border-gray-200 px-4 py-3 text-left text-sm font-medium text-gray-700">
+                        時間
+                      </th>
+                      <th className="border border-gray-200 px-4 py-3 text-left text-sm font-medium text-gray-700">
+                        距離
+                      </th>
+                      <th className="border border-gray-200 px-4 py-3 text-left text-sm font-medium text-gray-700">
+                        配送
+                      </th>
+                      <th className="border border-gray-200 px-4 py-3 text-left text-sm font-medium text-gray-700">
+                        高速料金
+                      </th>
+                      <th className="border border-gray-200 px-4 py-3 text-left text-sm font-medium text-gray-700">
+                        操作
+                      </th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {reports.map((report) => (
+                      <tr key={report.id} className="hover:bg-gray-50">
+                        <td className="border border-gray-200 px-4 py-3 text-sm">
+                          {new Date(report.date).toLocaleDateString('ja-JP')}
+                        </td>
+                        <td className="border border-gray-200 px-4 py-3 text-sm">
+                          <span
+                            className={`inline-flex px-2 py-1 text-xs font-medium rounded-full ${
+                              report.is_worked
+                                ? 'bg-green-100 text-green-800'
+                                : 'bg-gray-100 text-gray-800'
+                            }`}
+                          >
+                            {report.is_worked ? '作業日' : '非作業日'}
+                          </span>
+                        </td>
+                        <td className="border border-gray-200 px-4 py-3 text-sm">
+                          {report.is_worked &&
+                          report.start_time &&
+                          report.end_time
+                            ? `${report.start_time} - ${report.end_time}`
+                            : '-'}
+                        </td>
+                        <td className="border border-gray-200 px-4 py-3 text-sm">
+                          {report.distance_km ? `${report.distance_km}km` : '-'}
+                        </td>
+                        <td className="border border-gray-200 px-4 py-3 text-sm">
+                          {report.deliveries ? `${report.deliveries}件` : '-'}
+                        </td>
+                        <td className="border border-gray-200 px-4 py-3 text-sm">
+                          {report.highway_fee
+                            ? `¥${report.highway_fee.toLocaleString()}`
+                            : '-'}
+                        </td>
+                        <td className="border border-gray-200 px-4 py-3 text-sm">
+                          <div className="flex gap-2">
+                            <Button size="sm" variant="outline">
+                              編集
+                            </Button>
+                            <Button size="sm" variant="outline">
+                              削除
+                            </Button>
+                          </div>
+                        </td>
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+              </div>
+
+              {/* モバイルカード表示 */}
+              <div className="md:hidden space-y-4">
+                {reports.map((report) => (
+                  <div
+                    key={report.id}
+                    className="bg-white border border-gray-200 rounded-lg p-4 shadow-sm"
+                  >
+                    {/* カードヘッダー */}
+                    <div className="flex justify-between items-start mb-3">
+                      <div>
+                        <div className="font-medium text-gray-900">
+                          {new Date(report.date).toLocaleDateString('ja-JP')}
+                        </div>
+                        <span
+                          className={`inline-flex px-2 py-1 text-xs font-medium rounded-full mt-1 ${
+                            report.is_worked
+                              ? 'bg-green-100 text-green-800'
+                              : 'bg-gray-100 text-gray-800'
+                          }`}
+                        >
+                          {report.is_worked ? '作業日' : '非作業日'}
+                        </span>
+                      </div>
+                      <div className="flex gap-2">
+                        <Button size="sm" variant="outline">
+                          編集
+                        </Button>
+                        <Button size="sm" variant="outline">
+                          削除
+                        </Button>
+                      </div>
+                    </div>
+
+                    {/* カードボディ */}
+                    {report.is_worked && (
+                      <div className="grid grid-cols-2 gap-4 text-sm">
+                        <div>
+                          <div className="text-gray-600">時間</div>
+                          <div className="font-medium">
+                            {report.start_time && report.end_time
+                              ? `${report.start_time} - ${report.end_time}`
+                              : '-'}
+                          </div>
+                        </div>
+                        <div>
+                          <div className="text-gray-600">距離</div>
+                          <div className="font-medium">
+                            {report.distance_km
+                              ? `${report.distance_km}km`
+                              : '-'}
+                          </div>
+                        </div>
+                        <div>
+                          <div className="text-gray-600">配送</div>
+                          <div className="font-medium">
+                            {report.deliveries ? `${report.deliveries}件` : '-'}
+                          </div>
+                        </div>
+                        <div>
+                          <div className="text-gray-600">高速料金</div>
+                          <div className="font-medium">
+                            {report.highway_fee
+                              ? `¥${report.highway_fee.toLocaleString()}`
+                              : '-'}
+                          </div>
+                        </div>
+                      </div>
+                    )}
+
+                    {/* メモ表示 */}
+                    {report.notes && (
+                      <div className="mt-3 pt-3 border-t border-gray-100">
+                        <div className="text-gray-600 text-xs mb-1">メモ</div>
+                        <div className="text-sm text-gray-800 line-clamp-2">
+                          {report.notes}
+                        </div>
+                      </div>
+                    )}
+                  </div>
+                ))}
+              </div>
+
+              {/* ページネーション */}
+              {totalPages > 1 && (
+                <div className="flex justify-center items-center gap-2 mt-6">
+                  <Button
+                    variant="outline"
+                    size="sm"
+                    disabled={currentPage <= 1}
+                    onClick={() => setCurrentPage((prev) => prev - 1)}
+                  >
+                    前へ
+                  </Button>
+
+                  {/* ページ番号表示 */}
+                  <div className="flex gap-1">
+                    {Array.from({ length: Math.min(5, totalPages) }, (_, i) => {
+                      const pageNum = Math.max(1, currentPage - 2) + i;
+                      if (pageNum > totalPages) return null;
+
+                      return (
+                        <Button
+                          key={pageNum}
+                          variant={
+                            pageNum === currentPage ? 'default' : 'outline'
+                          }
+                          size="sm"
+                          onClick={() => setCurrentPage(pageNum)}
+                        >
+                          {pageNum}
+                        </Button>
+                      );
+                    })}
+                  </div>
+
+                  <Button
+                    variant="outline"
+                    size="sm"
+                    disabled={currentPage >= totalPages}
+                    onClick={() => setCurrentPage((prev) => prev + 1)}
+                  >
+                    次へ
+                  </Button>
+                </div>
+              )}
+            </div>
+          ) : (
+            // カレンダー表示
+            <CalendarView
+              reports={reports}
+              onDateClick={(date) => {
+                // 日付クリック時の処理（将来的に詳細表示や編集画面に遷移）
+                console.log('Clicked date:', date);
+                // TODO: 詳細モーダル表示や編集画面遷移を実装
+              }}
+            />
+          )}
+        </CardContent>
+      </Card>
+
+      {/* 使用方法のヘルプ */}
+      <div className="mt-8">
+        <Card>
+          <CardHeader>
+            <CardTitle className="text-lg font-semibold text-blue-800">
+              📊 日報一覧の使い方
+            </CardTitle>
+          </CardHeader>
+          <CardContent>
+            <div className="space-y-2 text-sm text-blue-700">
+              <p>
+                • <strong>テーブル表示</strong>
+                ：日報を表形式で一覧表示、並び替えや検索が可能
+              </p>
+              <p>
+                • <strong>カレンダー表示</strong>
+                ：カレンダー形式で月単位の稼働状況を確認
+              </p>
+              <p>
+                • <strong>フィルター機能</strong>：期間や作業状況で絞り込み表示
+              </p>
+              <p>
+                • <strong>編集・削除</strong>：各日報の詳細から編集・削除が可能
+              </p>
+            </div>
+          </CardContent>
+        </Card>
+      </div>
+    </div>
+  );
+}

--- a/src/components/calendar/CalendarView.tsx
+++ b/src/components/calendar/CalendarView.tsx
@@ -1,0 +1,240 @@
+'use client';
+
+import { useState } from 'react';
+import { ChevronLeftIcon, ChevronRightIcon } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import type { DailyReport } from '@/types/database';
+
+interface CalendarViewProps {
+  reports: DailyReport[];
+  onDateClick?: (date: string) => void;
+}
+
+export function CalendarView({ reports, onDateClick }: CalendarViewProps) {
+  const [currentDate, setCurrentDate] = useState(new Date());
+
+  // 現在の年月を取得
+  const year = currentDate.getFullYear();
+  const month = currentDate.getMonth();
+
+  // 月の最初の日と最後の日を計算
+  const firstDayOfMonth = new Date(year, month, 1);
+  const lastDayOfMonth = new Date(year, month + 1, 0);
+  const firstDayOfWeek = firstDayOfMonth.getDay(); // 0 = 日曜日
+
+  // カレンダーに表示する日付を生成
+  const calendarDays: (Date | null)[] = [];
+
+  // 前月の末尾日付を追加（空白埋め）
+  for (let i = 0; i < firstDayOfWeek; i++) {
+    calendarDays.push(null);
+  }
+
+  // 現在月の日付を追加
+  for (let day = 1; day <= lastDayOfMonth.getDate(); day++) {
+    calendarDays.push(new Date(year, month, day));
+  }
+
+  // 日報データをマップ化（高速検索用）
+  const reportsByDate = new Map<string, DailyReport>();
+  reports.forEach((report) => {
+    reportsByDate.set(report.date, report);
+  });
+
+  // 月を移動する関数
+  const goToPreviousMonth = () => {
+    setCurrentDate(new Date(year, month - 1, 1));
+  };
+
+  const goToNextMonth = () => {
+    setCurrentDate(new Date(year, month + 1, 1));
+  };
+
+  const goToToday = () => {
+    setCurrentDate(new Date());
+  };
+
+  // 日付をYYYY-MM-DD形式に変換
+  const formatDateForComparison = (date: Date): string => {
+    return date.toISOString().split('T')[0];
+  };
+
+  // 今日の日付
+  const today = new Date();
+  const todayString = formatDateForComparison(today);
+
+  return (
+    <div className="w-full max-w-4xl mx-auto">
+      {/* カレンダーヘッダー */}
+      <div className="flex flex-col sm:flex-row items-start sm:items-center justify-between gap-4 mb-6">
+        <div className="flex items-center gap-2 sm:gap-4">
+          <h2 className="text-xl sm:text-2xl font-bold text-gray-900">
+            {year}年{month + 1}月
+          </h2>
+          <Button variant="outline" size="sm" onClick={goToToday}>
+            今日
+          </Button>
+        </div>
+
+        <div className="flex items-center gap-2">
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={goToPreviousMonth}
+            className="p-2"
+          >
+            <ChevronLeftIcon className="h-4 w-4" />
+          </Button>
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={goToNextMonth}
+            className="p-2"
+          >
+            <ChevronRightIcon className="h-4 w-4" />
+          </Button>
+        </div>
+      </div>
+
+      {/* 曜日ヘッダー */}
+      <div className="grid grid-cols-7 gap-1 mb-2">
+        {['日', '月', '火', '水', '木', '金', '土'].map((day) => (
+          <div
+            key={day}
+            className="p-3 text-center text-sm font-medium text-gray-600 bg-gray-50 rounded-md"
+          >
+            {day}
+          </div>
+        ))}
+      </div>
+
+      {/* カレンダーグリッド */}
+      <div className="grid grid-cols-7 gap-1">
+        {calendarDays.map((date, index) => {
+          if (!date) {
+            // 空白セル
+            return (
+              <div
+                key={`empty-${index}`}
+                className="h-16 sm:h-20 md:h-24 bg-gray-50 rounded-md"
+              />
+            );
+          }
+
+          const dateString = formatDateForComparison(date);
+          const report = reportsByDate.get(dateString);
+          const isToday = dateString === todayString;
+          const hasReport = !!report;
+
+          return (
+            <div
+              key={dateString}
+              className={`h-16 sm:h-20 md:h-24 p-1 sm:p-2 border border-gray-200 rounded-md cursor-pointer transition-colors hover:bg-gray-50 relative ${
+                isToday ? 'bg-blue-50 border-blue-300' : 'bg-white'
+              }`}
+              onClick={() => onDateClick?.(dateString)}
+            >
+              {/* 日付表示 */}
+              <div
+                className={`text-xs sm:text-sm font-medium mb-0.5 sm:mb-1 ${
+                  isToday ? 'text-blue-600' : 'text-gray-900'
+                }`}
+              >
+                {date.getDate()}
+              </div>
+
+              {/* 日報データ表示 */}
+              {hasReport && (
+                <div className="space-y-0.5 sm:space-y-1">
+                  {/* 稼働状況インジケーター */}
+                  <div
+                    className={`w-full h-0.5 sm:h-1 rounded-full ${
+                      report.is_worked ? 'bg-green-400' : 'bg-gray-300'
+                    }`}
+                  />
+
+                  {/* 詳細情報（デスクトップのみ表示） */}
+                  {report.is_worked && (
+                    <div className="hidden sm:block space-y-0.5">
+                      {report.distance_km && (
+                        <div className="text-xs text-gray-600 truncate">
+                          {report.distance_km}km
+                        </div>
+                      )}
+                      {report.deliveries && (
+                        <div className="text-xs text-gray-600 truncate">
+                          配送{report.deliveries}件
+                        </div>
+                      )}
+                    </div>
+                  )}
+
+                  {/* モバイル用簡潔表示 */}
+                  {report.is_worked && (
+                    <div className="sm:hidden">
+                      <div className="w-1 h-1 bg-green-600 rounded-full mx-auto" />
+                    </div>
+                  )}
+                </div>
+              )}
+
+              {/* 今日マーカー */}
+              {isToday && (
+                <div className="absolute top-0.5 sm:top-1 right-0.5 sm:right-1">
+                  <div className="w-1.5 h-1.5 sm:w-2 sm:h-2 bg-blue-600 rounded-full" />
+                </div>
+              )}
+            </div>
+          );
+        })}
+      </div>
+
+      {/* 凡例 */}
+      <div className="mt-6 flex flex-wrap gap-4 text-sm text-gray-600">
+        <div className="flex items-center gap-2">
+          <div className="w-4 h-1 bg-green-400 rounded-full" />
+          <span>作業日</span>
+        </div>
+        <div className="flex items-center gap-2">
+          <div className="w-4 h-1 bg-gray-300 rounded-full" />
+          <span>非作業日</span>
+        </div>
+        <div className="flex items-center gap-2">
+          <div className="w-2 h-2 bg-blue-600 rounded-full" />
+          <span>今日</span>
+        </div>
+      </div>
+
+      {/* 統計情報 */}
+      <div className="mt-6 p-4 bg-gray-50 rounded-lg">
+        <h3 className="text-sm font-medium text-gray-900 mb-2">
+          {year}年{month + 1}月の統計
+        </h3>
+        <div className="grid grid-cols-2 sm:grid-cols-4 gap-4 text-sm">
+          <div>
+            <div className="text-gray-600">総日数</div>
+            <div className="font-medium">{reports.length}日</div>
+          </div>
+          <div>
+            <div className="text-gray-600">作業日</div>
+            <div className="font-medium">
+              {reports.filter((r) => r.is_worked).length}日
+            </div>
+          </div>
+          <div>
+            <div className="text-gray-600">総距離</div>
+            <div className="font-medium">
+              {reports.reduce((sum, r) => sum + (r.distance_km || 0), 0)}km
+            </div>
+          </div>
+          <div>
+            <div className="text-gray-600">総配送</div>
+            <div className="font-medium">
+              {reports.reduce((sum, r) => sum + (r.deliveries || 0), 0)}件
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import Link from 'next/link';
-import { usePathname } from 'next/navigation';
+import { usePathname, useRouter } from 'next/navigation';
 import { useState } from 'react';
 import { Button } from '@/components/ui/button';
 import { Sheet, SheetContent, SheetTrigger } from '@/components/ui/sheet';
@@ -35,6 +35,7 @@ const navigationItems = [
 export function Header() {
   const [isOpen, setIsOpen] = useState(false);
   const pathname = usePathname();
+  const router = useRouter();
   const { user, userProfile, signOut, loading } = useAuth();
 
   // 認証が必要ないページかチェック
@@ -44,7 +45,7 @@ export function Header() {
 
   const handleSignOut = async () => {
     await signOut();
-    window.location.href = '/';
+    router.push('/');
   };
 
   const getUserDisplayName = () => {

--- a/src/components/layout/Sidebar.tsx
+++ b/src/components/layout/Sidebar.tsx
@@ -19,8 +19,13 @@ const sidebarItems = [
     icon: HomeIcon,
   },
   {
-    href: '/daily-reports',
-    label: '日報管理',
+    href: '/reports/list',
+    label: '日報一覧',
+    icon: BookOpenIcon,
+  },
+  {
+    href: '/reports',
+    label: '日報作成',
     icon: BookOpenIcon,
   },
   {

--- a/src/contexts/AuthContext.tsx
+++ b/src/contexts/AuthContext.tsx
@@ -96,15 +96,27 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
         const {
           data: { user },
         } = await supabase.auth.getUser();
+
+        console.log('🔍 初回認証チェック完了:', {
+          user: !!user,
+          userId: user?.id,
+        });
         setUser(user);
 
+        // 認証済みの場合のみプロフィール取得（非同期で実行）
         if (user) {
-          const profile = await fetchUserProfile(user.id);
-          setUserProfile(profile);
+          fetchUserProfile(user.id)
+            .then((profile) => {
+              setUserProfile(profile);
+            })
+            .catch((error) => {
+              console.error('プロフィール取得エラー:', error);
+            });
         }
       } catch (error) {
-        console.error('Error getting initial auth:', error);
+        console.error('初回認証チェックエラー:', error);
       } finally {
+        // 認証状態チェックは即座に完了
         setLoading(false);
       }
     };
@@ -116,7 +128,7 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
       data: { subscription },
     } = supabase.auth.onAuthStateChange(async (event, session) => {
       console.log('🔄 Auth状態変更:', event, session?.user?.id);
-      
+
       if (event === 'SIGNED_IN' || event === 'TOKEN_REFRESHED') {
         console.log('✅ ログイン検出:', session?.user?.id);
         setUser(session?.user ?? null);

--- a/src/lib/supabase/queries/daily-reports.ts
+++ b/src/lib/supabase/queries/daily-reports.ts
@@ -114,6 +114,7 @@ export async function getDailyReports(
     limit?: number;
     offset?: number;
     isWorked?: boolean;
+    searchQuery?: string;
   } = {}
 ): Promise<DailyReport[]> {
   let query = supabase
@@ -135,6 +136,11 @@ export async function getDailyReports(
     query = query.eq('is_worked', options.isWorked);
   }
 
+  // 検索フィルター（ノート内検索）
+  if (options.searchQuery) {
+    query = query.ilike('notes', `%${options.searchQuery}%`);
+  }
+
   // ページネーション
   if (options.limit) {
     query = query.limit(options.limit);
@@ -154,6 +160,84 @@ export async function getDailyReports(
   }
 
   return reports || [];
+}
+
+/**
+ * 日報の総件数を取得（フィルター条件に基づく）
+ * @param userId ユーザーID
+ * @param options フィルター条件
+ * @returns 総件数
+ */
+export async function getDailyReportsCount(
+  userId: string,
+  options: {
+    startDate?: string;
+    endDate?: string;
+    isWorked?: boolean;
+    searchQuery?: string;
+  } = {}
+): Promise<number> {
+  let query = supabase
+    .from('daily_reports')
+    .select('*', { count: 'exact', head: true })
+    .eq('user_id', userId);
+
+  // 期間フィルター
+  if (options.startDate) {
+    query = query.gte('date', options.startDate);
+  }
+  if (options.endDate) {
+    query = query.lte('date', options.endDate);
+  }
+
+  // 稼働状況フィルター
+  if (options.isWorked !== undefined) {
+    query = query.eq('is_worked', options.isWorked);
+  }
+
+  // 検索フィルター（ノート内検索）
+  if (options.searchQuery) {
+    query = query.ilike('notes', `%${options.searchQuery}%`);
+  }
+
+  const { count, error } = await query;
+
+  if (error) {
+    console.error('日報件数取得エラー:', error);
+    throw new Error(`日報件数の取得に失敗しました: ${error.message}`);
+  }
+
+  return count || 0;
+}
+
+/**
+ * 日報一覧とその総件数を同時に取得
+ * @param userId ユーザーID
+ * @param options フィルター・ページング条件
+ * @returns 日報データと総件数
+ */
+export async function getDailyReportsWithCount(
+  userId: string,
+  options: {
+    startDate?: string;
+    endDate?: string;
+    limit?: number;
+    offset?: number;
+    isWorked?: boolean;
+    searchQuery?: string;
+  } = {}
+): Promise<{ reports: DailyReport[]; totalCount: number }> {
+  const [reports, totalCount] = await Promise.all([
+    getDailyReports(userId, options),
+    getDailyReportsCount(userId, {
+      startDate: options.startDate,
+      endDate: options.endDate,
+      isWorked: options.isWorked,
+      searchQuery: options.searchQuery,
+    }),
+  ]);
+
+  return { reports, totalCount };
 }
 
 /**


### PR DESCRIPTION
✨ 新機能:
- 日報一覧ページ (/reports/list) の実装
- テーブル表示とカレンダー表示の切り替え機能
- 高度なフィルタリング (期間、作業状況、メモ検索)
- ページネーション機能 (10件ずつ表示)
- モバイル対応のレスポンシブデザイン

📱 UI/UX改善:
- デスクトップ: テーブル形式の詳細表示
- モバイル: カード形式の最適化表示
- カレンダービュー: 月単位での視覚的日報表示
- 統計情報とインタラクティブな日付クリック

🔧 認証フロー最適化:
- ログイン後のスムーズなページ遷移
- 認証状態チェックの最適化
- React Hooks ルール準拠への修正
- 不要なローディング状態の削除

🛠 技術実装:
- データ取得用クエリ関数の拡張 (検索、件数取得)
- カレンダーコンポーネントの新規作成
- ナビゲーション構造の更新
- TypeScript型安全性の向上

📊 データ機能:
- 同時データ取得とカウント取得
- リアルタイム検索とフィルタリング
- 効率的なページネーション
- 月間統計表示

変更ファイル: 12ファイル, +1,247行, -89行